### PR TITLE
Bugfix for NODRAWDISTANCE

### DIFF
--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -181,10 +181,9 @@ void bhv_snufit_balls_loop(void) {
     // If far from Mario or in a different room, despawn.
     if ((o->activeFlags & ACTIVE_FLAG_IN_DIFFERENT_ROOM)
 #ifndef NODRAWINGDISTANCE
-        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)) {
-#else
-        || (o->oTimer != 0)) {
+        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)
 #endif
+            ){
         obj_mark_for_deletion(o);
     }
 


### PR DESCRIPTION
The bullets snufit shoots gets immediately deleted after snufit shoots them when NODRAWDISTANCE was enabled. This seems to fix it.