### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please contribute **first** to the [nightly branch](https://github.com/sm64pc/sm
  * Cheats menu in Options (activate with `--cheats` or by pressing L thrice in the pause menu).
  * Support for both little-endian and big-endian save files (meaning you can use save files from both sm64-port and most emulators), as well as an optional text-based save format.
 
-Recent changes in Nightly have moved the save and configuration file path to `%HOMEPATH%\AppData\Roaming\sm64pc` on Windows and `$HOME/.local/share/sm64pc` on Linux. This behaviour can be changed with the `--savepath` CLI option.
+Recent changes in Nightly have moved the save and configuration file path to `%HOMEPATH%\AppData\Roaming\sm64ex` on Windows and `$HOME/.local/share/sm64ex` on Linux. This behaviour can be changed with the `--savepath` CLI option.
 For example `--savepath .` will read saves from the current directory (which not always matches the exe directory, but most of the time it does);
    `--savepath '!'` will read saves from the executable directory.
 


### PR DESCRIPTION
Change path references from `sm64pc` to `sm64ex`, as I noticed after building and testing the executables on Windows that the path names in `%HOMEPATH%\AppData\Roaming\` was slightly different than what was referenced in the readme.

Presumably this slight change in naming extends to Linux, but I haven't tested personally.