### PR TITLE
Make tree only Cylboard when "BETTERCAMERA" is detected

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -12,9 +12,6 @@
 #include "game/debug.h"
 #include "menu/file_select.h"
 #include "engine/surface_load.h"
-#ifdef BETTERCAMERA
-#include "game/bettercamera.h"
-#endif
 
 #include "actors/common0.h"
 #include "actors/common1.h"
@@ -3186,11 +3183,11 @@ const BehaviorScript bhvFloorTrapInCastle[] = {
 
 const BehaviorScript bhvTree[] = {
     BEGIN(OBJ_LIST_POLELIKE),
-	#ifdef BETTERCAMERA
+    #ifdef BETTERCAMERA
     CYLBOARD(),
-	#else
-	BILLBOARD(),
-	#endif
+    #else
+    BILLBOARD(),
+    #endif
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     SET_INT(oInteractType, INTERACT_POLE),
     SET_HITBOX(/*Radius*/ 80, /*Height*/ 500),

--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -12,6 +12,9 @@
 #include "game/debug.h"
 #include "menu/file_select.h"
 #include "engine/surface_load.h"
+#ifdef BETTERCAMERA
+#include "game/bettercamera.h"
+#endif
 
 #include "actors/common0.h"
 #include "actors/common1.h"
@@ -3183,7 +3186,11 @@ const BehaviorScript bhvFloorTrapInCastle[] = {
 
 const BehaviorScript bhvTree[] = {
     BEGIN(OBJ_LIST_POLELIKE),
+	#ifdef BETTERCAMERA
     CYLBOARD(),
+	#else
+	BILLBOARD(),
+	#endif
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     SET_INT(oInteractType, INTERACT_POLE),
     SET_HITBOX(/*Radius*/ 80, /*Height*/ 500),


### PR DESCRIPTION
This fixes trees looking weird with the normal sm64 camera.