### PR TITLE
Forever Shell cheat

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -84,6 +84,7 @@
 #define TEXT_OPT_CHEAT7    _("EXIT COURSE AT ANY TIME")
 #define TEXT_OPT_CHEAT8    _("HUGE MARIO")
 #define TEXT_OPT_CHEAT9    _("TINY MARIO")
+#define TEXT_OPT_FOREVER_SHELL    _("FOREVER SHELL")
 
 #else // VERSION
 
@@ -148,6 +149,7 @@
 #define TEXT_OPT_CHEAT7    _("Exit course at any time")
 #define TEXT_OPT_CHEAT8    _("Huge Mario")
 #define TEXT_OPT_CHEAT9    _("Tiny Mario")
+#define TEXT_OPT_FOREVER_SHELL    _("Forever Shell")
 
 #endif // VERSION
 

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -1235,11 +1235,11 @@ s32 act_riding_shell_ground(struct MarioState *m) {
             break;
 
         case GROUND_STEP_HIT_WALL:
-            mario_stop_riding_object(m);
+            if (!Cheats.EnableCheats || !Cheats.ForeverShell) { mario_stop_riding_object(m); }
             play_sound(m->flags & MARIO_METAL_CAP ? SOUND_ACTION_METAL_BONK : SOUND_ACTION_BONK,
                        m->marioObj->header.gfx.cameraToObject);
             m->particleFlags |= PARTICLE_VERTICAL_STAR;
-            set_mario_action(m, ACT_BACKWARD_GROUND_KB, 0);
+            if (!Cheats.EnableCheats || !Cheats.ForeverShell) { set_mario_action(m, ACT_BACKWARD_GROUND_KB, 0); }
             break;
     }
 

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -279,6 +279,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[6], &Cheats.ExitAnywhere ),
     DEF_OPT_TOGGLE( optsCheatsStr[7], &Cheats.HugeMario ),
     DEF_OPT_TOGGLE( optsCheatsStr[8], &Cheats.TinyMario ),
+    DEF_OPT_TOGGLE( optsCheatsStr[9], &Cheats.ForeverShell ),
 
 };
 

--- a/src/pc/cheats.h
+++ b/src/pc/cheats.h
@@ -13,6 +13,7 @@ struct CheatList {
     bool         ExitAnywhere;
     bool         HugeMario;
     bool         TinyMario;
+    bool         ForeverShell;
 };
 
 extern struct CheatList Cheats;


### PR DESCRIPTION
This cheat allows Mario keeps the Shell riding even when hits the wall