### PR TITLE
fix mac build for exoquant

### DIFF
--- a/tools/n64graphics_ci_dir/exoquant/exoquant.c
+++ b/tools/n64graphics_ci_dir/exoquant/exoquant.c
@@ -24,7 +24,9 @@ SOFTWARE.
 
 #include "exoquant.h"
 
-#ifndef OSX_BUILD // OSX build cannot have malloc defined
+#ifdef __APPLE__
+// No malloc on mac
+#else
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
OSX_BUILD isn't passed