### PR TITLE
Add level reset cheat

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -84,6 +84,7 @@
 #define TEXT_OPT_CHEAT7    _("EXIT COURSE AT ANY TIME")
 #define TEXT_OPT_CHEAT8    _("HUGE MARIO")
 #define TEXT_OPT_CHEAT9    _("TINY MARIO")
+#define TEXT_OPT_CHEAT10   _("LEVEL RESET (PRESS L)")
 
 #else // VERSION
 
@@ -148,6 +149,7 @@
 #define TEXT_OPT_CHEAT7    _("Exit course at any time")
 #define TEXT_OPT_CHEAT8    _("Huge Mario")
 #define TEXT_OPT_CHEAT9    _("Tiny Mario")
+#define TEXT_OPT_CHEAT10   _("Level Reset (Press L)")
 
 #endif // VERSION
 

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1421,6 +1421,19 @@ void update_mario_inputs(struct MarioState *m) {
     }
     /*End of moonjump cheat */
 
+    /* Level reset cheat */
+    if (Cheats.LevelReset
+                && Cheats.EnableCheats
+                && m->controller->buttonDown & L_TRIG
+                // Prevent crashing if there's no warp destination
+                && sWarpDest.areaIdx != 0) {
+        m->health = 0x880;
+        m->numCoins = 0;
+        gHudDisplay.coins = 0;
+        sWarpDest.type = 2;
+    }
+    /* End of level reset cheat */
+
     if (gCameraMovementFlags & CAM_MOVE_C_UP_MODE) {
         if (m->action & ACT_FLAG_ALLOW_FIRST_PERSON) {
             m->input |= INPUT_FIRST_PERSON;

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -102,6 +102,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT7 },
     { TEXT_OPT_CHEAT8 },
     { TEXT_OPT_CHEAT9 },
+    { TEXT_OPT_CHEAT10 },
 };
 
 static const u8 bindStr[][32] = {
@@ -279,6 +280,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[6], &Cheats.ExitAnywhere ),
     DEF_OPT_TOGGLE( optsCheatsStr[7], &Cheats.HugeMario ),
     DEF_OPT_TOGGLE( optsCheatsStr[8], &Cheats.TinyMario ),
+    DEF_OPT_TOGGLE( optsCheatsStr[9], &Cheats.LevelReset ),
 
 };
 

--- a/src/pc/cheats.h
+++ b/src/pc/cheats.h
@@ -13,6 +13,7 @@ struct CheatList {
     bool         ExitAnywhere;
     bool         HugeMario;
     bool         TinyMario;
+    bool         LevelReset;
 };
 
 extern struct CheatList Cheats;


### PR DESCRIPTION
This implements the level reset cheat for speedrunning practice.

Resolves part of https://github.com/sm64pc/sm64ex/issues/355.