### PR TITLE
Check for zero rumble setting before allowing rumble

### DIFF
--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,12 +33,16 @@ s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *
 s32 osMotorStart(UNUSED void *pfs) {
     // Since rumble stops by osMotorStop, its duration is not nessecary.
     // Set it to 5 seconds and hope osMotorStop() is called in time.
-    controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
+    if (configRumbleStrength>0){
+        controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
+    }
     return 0;
 }
 
 s32 osMotorStop(UNUSED void *pfs) {
-    controller_rumble_stop();
+    if (configRumbleStrength>0){
+        controller_rumble_stop();
+    }
     return 0;
 }
 


### PR DESCRIPTION
Fixes controllers which don't check for rumble_strength and have constant rumble from rumbling even when set to 0 in the config.