### PR TITLE
BUGFIX:  Text Saves aren't saving cannon flags. #397

### DIFF
--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -615,6 +615,12 @@ u32 save_file_get_star_flags(s32 fileIndex, s32 courseIndex) {
 
     return starFlags;
 }
+u32 save_file_get_cannon_flags(s32 fileIndex, s32 courseIndex) {
+    
+    if (gSaveBuffer.files[fileIndex][0].courseStars[courseIndex+1] & 0x80){return 1;}
+
+    return 0;
+}
 
 /**
  * Add to the bitset of obtained stars in the specified course.

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -135,6 +135,7 @@ void save_file_set_flags(u32 flags);
 void save_file_clear_flags(u32 flags);
 u32 save_file_get_flags(void);
 u32 save_file_get_star_flags(s32 fileIndex, s32 courseIndex);
+u32 save_file_get_cannon_flags(s32 fileIndex, s32 courseIndex);
 void save_file_set_star_flags(s32 fileIndex, s32 courseIndex, u32 starFlags);
 s32 save_file_get_course_coin_score(s32 fileIndex, s32 courseIndex);
 s32 save_file_is_cannon_unlocked(void);

--- a/src/game/text_save.inc.h
+++ b/src/game/text_save.inc.h
@@ -81,7 +81,7 @@ static s32 write_text_save(s32 fileIndex) {
     struct MainMenuSaveData *menudata;
     char filename[SYS_MAX_PATH] = { 0 };
     char value[64];
-    u32 i, bit, flags, coins, stars, starFlags;
+    u32 i, bit, flags, coins, stars, starFlags, cannonFlag;
 
     if (snprintf(filename, sizeof(filename), FILENAME_FORMAT, fs_writepath, fileIndex) < 0)
         return -1;
@@ -133,9 +133,10 @@ static s32 write_text_save(s32 fileIndex) {
     for (i = 0; i < NUM_COURSES; i++) {
         stars = save_file_get_star_flags(fileIndex, i);
         coins = save_file_get_course_coin_score(fileIndex, i);
+        cannonFlag = save_file_get_cannon_flags(fileIndex, i);
         starFlags = int_to_bin(stars);      // 63 -> 111111
             
-        fprintf(file, "%s = \"%d, %07d\"\n", sav_courses[i], coins, starFlags);
+        fprintf(file, "%s = \"%d, %07d, %d\"\n", sav_courses[i], coins, starFlags,cannonFlag);
     }
 
     fprintf(file, "\n[bonus]\n");
@@ -208,7 +209,7 @@ static s32 read_text_save(s32 fileIndex) {
     const char *value;
     ini_t *savedata;
     
-    u32 i, flag, coins, stars, starFlags;
+    u32 i, flag, coins, stars, starFlags, cannonFlag;
     u32 capArea;
     
     if (snprintf(filename, sizeof(filename), FILENAME_FORMAT, fs_writepath, fileIndex) < 0)
@@ -255,9 +256,10 @@ static s32 read_text_save(s32 fileIndex) {
     for (i = 0; i < NUM_COURSES; i++) {
         value = ini_get(savedata, "courses", sav_courses[i]);
         if (value) {
-            sscanf(value, "%d, %d", &coins, &stars); 
+            sscanf(value, "%d, %d, %d", &coins, &stars, &cannonFlag); 
             starFlags = bin_to_int(stars);      // 111111 -> 63
-
+            cannonFlag <<= 7; //Shifts the bit to the most significant bit.
+            save_file_set_star_flags(fileIndex, i+1, cannonFlag); //
             save_file_set_star_flags(fileIndex, i, starFlags);
             gSaveBuffer.files[fileIndex][0].courseCoinScores[i] = coins;
         }


### PR DESCRIPTION
This should fix #397 Text Saves aren't saving cannon flags.  Old text saves should still be compatible with the new format and will be automatically converted when saving.