### PR TITLE
Fixes Bugs in SM64 (intended for a normal playthrough, so look away if you are a speedrunner)

### DIFF
--- a/Fixes.md
+++ b/Fixes.md
@@ -1,0 +1,8 @@
+- Patched the Backwards Long Jump #NoFunAllowed
+- The drowning noise when Mario is close to drowning no longer plays when Mario has the metal cap
+- You can now get 1ups every 50 coins when finishing a course (was capped as 150 as the developers never thought anyone would get to 200+)
+- Patched "Blast away the wall" skip
+- Patched the Lakitu Skip
+- Patched triple jumping & Kicking on slopes #NoFunAllowed
+- Patched the Hands-free holding when bonking #NoFunAllowed
+- Patched the "Zombie Mario" Glitch by a cannon

--- a/levels/wf/script.c
+++ b/levels/wf/script.c
@@ -40,7 +40,7 @@ static const LevelScript script_func_local_2[] = {
     OBJECT(/*model*/ MODEL_WF_SLIDING_PLATFORM,         /*pos*/  3328, 1075,  -767, /*angle*/ 0,  90, 0, /*behParam*/ 0x00010000, /*beh*/ bhvWfSlidingPlatform),
     OBJECT(/*model*/ MODEL_WF_SLIDING_PLATFORM,         /*pos*/  3328, 1075, -2815, /*angle*/ 0,  90, 0, /*behParam*/ 0x00030000, /*beh*/ bhvWfSlidingPlatform),
     OBJECT(/*model*/ MODEL_WF_TUMBLING_BRIDGE,          /*pos*/  1792, 2496,  1600, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfTumblingBridge),
-    OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_RIGHT,     /*pos*/   512, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfBreakableWallRight),
+    OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_RIGHT,     /*pos*/   512, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x05000000, /*beh*/ bhvWfBreakableWallRight),
     OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_LEFT,      /*pos*/ -1023, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfBreakableWallLeft),
     OBJECT_WITH_ACTS(/*model*/ MODEL_WF_KICKABLE_BOARD,           /*pos*/    13, 3584, -1407, /*angle*/ 0, 315, 0, /*behParam*/ 0x00000000, /*beh*/ bhvKickableBoard, /*acts*/ ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6),
     OBJECT_WITH_ACTS(/*model*/ MODEL_1UP,                         /*pos*/  -384, 3584,     6, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhv1Up,            /*acts*/ ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6),
@@ -87,7 +87,6 @@ static const LevelScript script_func_local_4[] = {
     OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/ -2500, 1500, -750, /*angle*/ 0, 0, 0, /*behParam*/ 0x02000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
     OBJECT_WITH_ACTS(/*model*/ MODEL_NONE,  /*pos*/  4600,  550, 2500, /*angle*/ 0, 0, 0, /*behParam*/ 0x03000000, /*beh*/ bhvHiddenRedCoinStar, /*acts*/ ALL_ACTS),
     OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/  2880, 4300,  190, /*angle*/ 0, 0, 0, /*behParam*/ 0x04000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
-    OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/   590, 2450, 2650, /*angle*/ 0, 0, 0, /*behParam*/ 0x05000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
     RETURN(),
 };
 
@@ -140,7 +139,7 @@ const LevelScript level_wf_entry[] = {
     LOAD_MODEL_FROM_GEO(MODEL_WF_KICKABLE_BOARD_FELLED,         wf_geo_000BC8),
 
     AREA(/*index*/ 1, wf_geo_000BF8),
-        OBJECT(/*model*/ MODEL_NONE, /*pos*/  2600, 1256,  5120, /*angle*/ 0, 90, 0, /*behParam*/ 0x000A0000, /*beh*/ bhvWarps74),
+        OBJECT(/*model*/ MODEL_NONE, /*pos*/  2600, 1256,  5120, /*angle*/ 0, 90, 0, /*behParam*/ 0x000A0000, /*beh*/ bhvSpinAirborneWarp),
         OBJECT(/*model*/ MODEL_NONE, /*pos*/ -2925, 2560,  -947, /*angle*/ 0, 19, 0, /*behParam*/ 0x000B0000, /*beh*/ bhvFadingWarp),
         OBJECT(/*model*/ MODEL_NONE, /*pos*/  2548, 1075, -3962, /*angle*/ 0, 51, 0, /*behParam*/ 0x000C0000, /*beh*/ bhvFadingWarp),
         WARP_NODE(/*id*/ 0x0A, /*destLevel*/ LEVEL_WF, /*destArea*/ 0x01, /*destNode*/ 0x0A, /*flags*/ WARP_NO_CHECKPOINT),

--- a/src/game/behaviors/breakable_wall.inc.c
+++ b/src/game/behaviors/breakable_wall.inc.c
@@ -5,6 +5,7 @@ void bhv_wf_breakable_wall_loop(void) {
         cur_obj_become_tangible();
         if (obj_check_if_collided_with_object(o, gMarioObject)) {
             if (cur_obj_has_behavior(bhvWfBreakableWallRight))
+				spawn_default_star(590.0f, 2450.0f, 2650.0f);
                 play_puzzle_jingle();
             create_sound_spawner(SOUND_GENERAL_WALL_EXPLOSION);
             o->oInteractType = 8;

--- a/src/game/behaviors/camera_lakitu.inc.c
+++ b/src/game/behaviors/camera_lakitu.inc.c
@@ -27,8 +27,9 @@ void bhv_camera_lakitu_init(void) {
  */
 static void camera_lakitu_intro_act_trigger_cutscene(void) {
     //! These bounds are slightly smaller than the actual bridge bounds, allowing
+	// not anymore :)
     //  the RTA speedrunning method of lakitu skip
-    if (gMarioObject->oPosX > -544.0f && gMarioObject->oPosX < 545.0f && gMarioObject->oPosY > 800.0f
+    if (gMarioObject->oPosX > -555.0f && gMarioObject->oPosX < 555.0f && gMarioObject->oPosY > 800.0f
         && gMarioObject->oPosZ > -2000.0f && gMarioObject->oPosZ < -177.0f
         && gMarioObject->oPosZ < -177.0f) // always double check your conditions
     {

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -1,25 +1,27 @@
-#include <ultra64.h>
+#include <PR/ultratypes.h>
 
-#include "sm64.h"
-#include "interaction.h"
-#include "camera.h"
-#include "level_update.h"
-#include "engine/math_util.h"
-#include "memory.h"
 #include "area.h"
-#include "save_file.h"
+#include "actors/common1.h"
+#include "audio/external.h"
+#include "behavior_actions.h"
+#include "behavior_data.h"
+#include "camera.h"
+#include "course_table.h"
+#include "dialog_ids.h"
+#include "engine/math_util.h"
 #include "engine/surface_collision.h"
-#include "sound_init.h"
 #include "game_init.h"
+#include "interaction.h"
+#include "level_update.h"
 #include "mario.h"
+#include "mario_step.h"
+#include "memory.h"
 #include "obj_behaviors.h"
 #include "object_helpers.h"
-#include "behavior_actions.h"
-#include "audio/external.h"
-#include "behavior_data.h"
-#include "dialog_ids.h"
+#include "save_file.h"
 #include "seq_ids.h"
-#include "course_table.h"
+#include "sm64.h"
+#include "sound_init.h"
 #include "thread6.h"
 
 #define INT_GROUND_POUND_OR_TWIRL (1 << 0) // 0x01
@@ -44,7 +46,6 @@
 
 u8 sDelayInvincTimer;
 s16 sInvulnerable;
-extern u8 warp_pipe_seg3_collision_03009AC8[];
 u32 interact_coin(struct MarioState *, u32, struct Object *);
 u32 interact_water_ring(struct MarioState *, u32, struct Object *);
 u32 interact_star_or_key(struct MarioState *, u32, struct Object *);
@@ -149,7 +150,7 @@ u32 get_mario_cap_flag(struct Object *capObject) {
     return 0;
 }
 /**
- * Returns true if the passed in object has a moving angle yaw 
+ * Returns true if the passed in object has a moving angle yaw
  * in the angular range given towards Mario.
  */
 u32 object_facing_mario(struct MarioState *m, struct Object *o, s16 angleRange) {
@@ -637,7 +638,7 @@ void push_mario_out_of_object(struct MarioState *m, struct Object *o, f32 paddin
 
         find_floor(newMarioX, m->pos[1], newMarioZ, &floor);
         if (floor != NULL) {
-            //! Doesn't update mario's referenced floor (allows oob death when
+            //! Doesn't update Mario's referenced floor (allows oob death when
             // an object pushes you into a steep slope while in a ground action)
             m->pos[0] = newMarioX;
             m->pos[2] = newMarioZ;
@@ -1049,7 +1050,7 @@ u32 interact_door(struct MarioState *m, UNUSED u32 interactType, struct Object *
 }
 
 u32 interact_cannon_base(struct MarioState *m, UNUSED u32 interactType, struct Object *o) {
-    if (m->action != ACT_IN_CANNON) {
+    if (m->action != ACT_IN_CANNON && m->health >= 0x100) {
         mario_stop_riding_and_holding(m);
         o->oInteractStatus = INT_STATUS_INTERACTED;
         m->interactObj = o;
@@ -1439,7 +1440,7 @@ u32 interact_koopa_shell(struct MarioState *m, UNUSED u32 interactType, struct O
             play_shell_music();
             mario_drop_held_object(m);
 
-            //! Puts mario in ground action even when in air, making it easy to
+            //! Puts Mario in ground action even when in air, making it easy to
             // escape air actions into crouch slide (shell cancel)
             return set_mario_action(m, ACT_RIDING_SHELL_GROUND, 0);
         }
@@ -1762,7 +1763,7 @@ void mario_process_interactions(struct MarioState *m) {
         m->invincTimer -= 1;
     }
 
-    //! If the kick/punch flags are set and an object collision changes mario's
+    //! If the kick/punch flags are set and an object collision changes Mario's
     // action, he will get the kick/punch wall speed anyway.
     check_kick_or_punch_wall(m);
     m->flags &= ~MARIO_PUNCHING & ~MARIO_KICKING & ~MARIO_TRIPPING;

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,16 +33,14 @@ s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *
 s32 osMotorStart(UNUSED void *pfs) {
     // Since rumble stops by osMotorStop, its duration is not nessecary.
     // Set it to 5 seconds and hope osMotorStop() is called in time.
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
-    }
     return 0;
 }
 
 s32 osMotorStop(UNUSED void *pfs) {
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_stop();
-    }
     return 0;
 }
 


### PR DESCRIPTION
- Patched the Backwards Long Jump
- The drowning noise when Mario is close to drowning no longer plays when Mario has the metal cap
- You can now get 1ups every 50 coins when finishing a course (was capped as 150 as the developers never thought anyone would get to 200+)
- Patched "Blast away the wall" skip
- Patched the Lakitu Skip
- Patched triple jumping & Kicking on slopes
- Patched the Hands-free holding when bonking
- Patched the "Zombie Mario" Glitch using a cannon