### PR TITLE
options_menu: confirm exit game fixes #247

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -10,6 +10,7 @@
 #define TEXT_OPT_CONTROLS  _("CONTROLS")
 #define TEXT_OPT_VIDEO     _("DISPLAY")
 #define TEXT_OPT_AUDIO     _("SOUND")
+#define TEXT_OPT_CONFIRM   _("CONFIRM")
 #define TEXT_OPT_CHEATS    _("CHEATS")
 
 // Markers

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -56,7 +56,7 @@ static const u8 menuStr[][32] = {
     { TEXT_OPT_AUDIO },
     { TEXT_EXIT_GAME },
     { TEXT_OPT_CHEATS },
-
+    { TEXT_OPT_CONFIRM }
 };
 
 static const u8 optsCameraStr[][32] = {
@@ -101,6 +101,10 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT7 },
     { TEXT_OPT_CHEAT8 },
     { TEXT_OPT_CHEAT9 },
+};
+
+static const u8 optsConfirmExitStr[][32] = {
+  { TEXT_YES }
 };
 
 static const u8 bindStr[][32] = {
@@ -280,15 +284,20 @@ static struct Option optsCheats[] = {
 
 };
 
+static struct Option optsConfirmExit[] = {
+    DEF_OPT_BUTTON( optsConfirmExitStr[0], optmenu_act_exit ),
+};
+
 /* submenu definitions */
 
 #ifdef BETTERCAMERA
 static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[4], optsCamera );
 #endif
-static struct SubMenu menuControls = DEF_SUBMENU( menuStr[5], optsControls );
-static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[6], optsVideo );
-static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[7], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[9], optsCheats );
+static struct SubMenu menuControls    = DEF_SUBMENU( menuStr[5], optsControls );
+static struct SubMenu menuVideo       = DEF_SUBMENU( menuStr[6], optsVideo );
+static struct SubMenu menuAudio       = DEF_SUBMENU( menuStr[7], optsAudio );
+static struct SubMenu menuCheats      = DEF_SUBMENU( menuStr[9], optsCheats );
+static struct SubMenu menuConfirmExit = DEF_SUBMENU( menuStr[10], optsConfirmExit );
 
 /* main options menu definition */
 
@@ -299,7 +308,7 @@ static struct Option optsMain[] = {
     DEF_OPT_SUBMENU( menuStr[5], &menuControls ),
     DEF_OPT_SUBMENU( menuStr[6], &menuVideo ),
     DEF_OPT_SUBMENU( menuStr[7], &menuAudio ),
-    DEF_OPT_BUTTON ( menuStr[8], optmenu_act_exit ),
+    DEF_OPT_SUBMENU ( menuStr[8], &menuConfirmExit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
     DEF_OPT_SUBMENU( menuStr[9], &menuCheats )
 };

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,16 +33,14 @@ s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *
 s32 osMotorStart(UNUSED void *pfs) {
     // Since rumble stops by osMotorStop, its duration is not nessecary.
     // Set it to 5 seconds and hope osMotorStop() is called in time.
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_play(configRumbleStrength / 100.0f, 5.0f);
-    }
     return 0;
 }
 
 s32 osMotorStop(UNUSED void *pfs) {
-    if (configRumbleStrength>0){
+    if (configRumbleStrength)
         controller_rumble_stop();
-    }
     return 0;
 }
 


### PR DESCRIPTION
This changes the "Exit Game" menu option to be a submenu with a confirm step, fixing #247:

![image](https://user-images.githubusercontent.com/141159/93831983-3fffef00-fc42-11ea-810f-723a2009419b.png)

![image](https://user-images.githubusercontent.com/141159/93831970-34acc380-fc42-11ea-877b-df3131027c11.png)

Player can press B to return back to the main option menu.

I chose "CONFIRM" because that was the best word I could find that would work with the characters available in the english HUD font. X, Q, and a few other letters are not available.