### PR TITLE
Fix EU build, fix its audio samples, fix its menu texts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ ifeq ($(OSX_BUILD),1) # Modify GFX & SDL2 for OSX GL
      VERSION_CFLAGS += -DOSX_BUILD
 endif
 
-VERSION_ASFLAGS := --defsym AVOID_UB=1
+# Append (don't overwrite) so VERSION_EU stays defined for the sequence assembler.
+VERSION_ASFLAGS := $(VERSION_ASFLAGS) --defsym AVOID_UB=1
 COMPARE := 0
 
 ifeq ($(TARGET_WEB),1)

--- a/src/audio/port_eu.c
+++ b/src/audio/port_eu.c
@@ -4,6 +4,7 @@
 #include "data.h"
 #include "seqplayer.h"
 #include "synthesis.h"
+#include "heap.h"
 
 #ifdef VERSION_EU
 

--- a/src/audio/port_eu.c
+++ b/src/audio/port_eu.c
@@ -42,6 +42,9 @@ void create_next_audio_buffer(s16 *samples, u32 num_samples) {
     s32 writtenCmds;
     OSMesg msg;
     gAudioFrameCount++;
+    // Reset per-frame DMA counter (N64 did this in the stubbed audio task);
+    // otherwise it overflows gCurrAudioFrameDmaIoMesgBufs[].
+    gCurrAudioFrameDmaCount = 0;
     decrease_sample_dma_ttls();
     if (osRecvMesg(OSMesgQueues[2], &msg, 0) != -1) {
         gAudioResetPresetIdToLoad = (u8) (s32) msg;

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2966,7 +2966,8 @@ void render_save_confirmation(s16 x, s16 y, s8 *index, s16 sp6e)
         { TEXT_SAVE_AND_QUIT_DE }
     };
 
-    u8 textSaveExitGame[][26] = { // New function to exit game
+    // 28: fits the German "SPEICHERN & SPIEL VERLASSEN" (27 chars + terminator).
+    u8 textSaveExitGame[][28] = {
         { TEXT_SAVE_EXIT_GAME },
         { TEXT_SAVE_EXIT_GAME_FR },
         { TEXT_SAVE_EXIT_GAME_DE }


### PR DESCRIPTION
Fixes the build failure described in https://github.com/sm64pc/sm64ex/issues/535 by adding `#include "heap.h"`. 

Additionally fixes the problem that audio cuts out after only a second in the title screen and ingame. The audio samples were always built for the US variant, a Makefile line overwrote previously existing options.

Additionally fixes a bug in the menu rendering that shows up after a level was finished. The german version's text was longer than 26 characters so it got weirdly overwritten. Increase it to 28.

Before:

<img width="1921" height="1049" alt="grafik" src="https://github.com/user-attachments/assets/ce24ee33-75e5-46d4-883c-429b665934b4" />

After:

<img width="1921" height="1049" alt="grafik" src="https://github.com/user-attachments/assets/2ebacfcd-c21c-4025-bde5-edcfc42453ed" />

So, this gets this game from unbuildable in the current version to nicely playable.